### PR TITLE
Enforce the correct apt PGP fingerprint.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,7 @@ owncloud_domain: [ 'owncloud.{{ ansible_domain }}' ]
 owncloud_edition: community
 owncloud_release: 8.0
 owncloud_apt_repo_base: 'http://download.opensuse.org/repositories/isv:/ownCloud:'
+owncloud_apt_repo_key_fingerprint: 'F9EA4996747310AE79474F44977C43A8BA684223'
 
 # User and group that will be used for ownCloud instance
 owncloud_user: 'www-data'

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,6 +8,7 @@ dependencies:
       state: present
     apt_keys:
     - url: '{{owncloud_apt_repo_base}}/{{owncloud_edition}}:/{{owncloud_release}}/{{ansible_distribution}}_{{ansible_distribution_major_version}}.0/Release.key'
+      id: '{{ owncloud_apt_repo_key_fingerprint }}'
       state: present
 
   - role: debops.secret


### PR DESCRIPTION
If it ever changes then it might be required to create a more complex
variable (dict) for the different version or something like this.

The ID field does currently not seem to check all of the fingerprint, not sure (try changing one of the first characters of the fingerprint). But it works nevertheless.
