### PR TITLE
Allow to create users via the `occ` command.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,4 +12,4 @@ v0.2.0
 
 - Updated to ownCloud 8.1. [ypid]
 
-- Allow to use ``ooc`` via Ansible’s inventory. Can be used to enable apps for instance. [ypid]
+- Allow to use ``ooc`` via Ansible’s inventory. Can be used to enable apps and create users. [ypid]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,3 +13,6 @@ v0.2.0
 - Updated to ownCloud 8.1. [ypid]
 
 - Allow to use ``ooc`` via Ansible’s inventory. Can be used to enable apps and create users. [ypid]
+
+- Setup shortcut for the `occ` command when not logged in as ``owncloud_user`` user and sudo allows it.
+  Disabled by default. Can be enabled via ``owncloud_enable_occ_shortcut``. [ypid]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -261,6 +261,13 @@ owncloud_initial_config_group: {}
 owncloud_initial_config: {}
 
 
+# .. envvar:: owncloud_enable_occ_shortcut
+#
+# Make the `occ` command accessible in the ``PATH`` of all users.
+# Permissions are handled by ``sudo``.
+owncloud_enable_occ_shortcut: False
+
+
 # .. envvar:: owncloud_run_occ_global_commands
 #
 # Run the list of occ commands. It can be used to enable apps, add users and

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -267,11 +267,28 @@ owncloud_initial_config: {}
 # more which can be useful when deploying ownCloud.
 # See: https://doc.owncloud.org/server/8.1/admin_manual/configuration_server/occ_command.html
 owncloud_run_occ_global_commands: []
-  ## Also requires: php5-ldap
-  # - 'app:enable user_ldap'
+  ## Requires: php5-ldap
+  # - command: 'app:enable user_ldap'
 
-  # - 'app:enable external'
-  # - 'app:enable files_external'
+  # - command: 'app:enable external'
+
+  ## Requires: php5-libsmbclient
+  # - command: 'app:enable files_external'
+
+  ## Create an additional admin account.
+  # - command: 'user:add --password-from-env --display-name="Administrator" --group="admin" admin'
+  #   env:
+  #     OC_PASS: "{{ lookup('password', secret + '/credentials/' +
+  #                  ansible_fqdn + '/owncloud/admin/' + 'admin' +
+  #                  '/password length=' + owncloud_password_length) }}"
+
+  ## Create an regular user. Note that you probably want to use an existing
+  ## user database like LDAP if that is setup in your environment.
+  # - command: 'user:add --password-from-env --display-name="Normal user" user'
+  #   env:
+  #     OC_PASS: "{{ lookup('password', secret + '/credentials/' +
+  #                  ansible_fqdn + '/owncloud/users/' + 'user' +
+  #                  '/password length=' + owncloud_password_length) }}"
 
 
 # .. envvar:: owncloud_run_occ_group_commands

--- a/tasks/configure_owncloud.yml
+++ b/tasks/configure_owncloud.yml
@@ -91,10 +91,13 @@
   tags: [ 'role::owncloud:occ' ]
 
 - name: Run specified occ commands
-  command: occ {{ item }}
-  changed_when: ('is already enabled' not in owncloud_occ_run.stdout)
+  command: occ {{ item.command }}
+  environment: '{{ item.env|d({}) }}'
+  changed_when: ('is already enabled' not in owncloud_occ_run.stdout and
+                  'already exists' not in owncloud_occ_run.stdout)
+  failed_when: (owncloud_occ_run.rc != 0 and 'already exists' not in owncloud_occ_run.stdout)
   register: owncloud_occ_run
-  when: item|d()
+  when: item|d() and item.command|d()
   with_flattened:
     - owncloud_run_occ_global_commands
     - owncloud_run_occ_group_commands

--- a/tasks/configure_owncloud.yml
+++ b/tasks/configure_owncloud.yml
@@ -87,17 +87,26 @@
     dest: '/usr/local/bin/occ'
     owner: 'root'
     group: '{{ owncloud_group }}'
-    mode: 0750
+    mode: 0755
+  when: owncloud_enable_occ_shortcut|d()
+  tags: [ 'role::owncloud:occ' ]
+
+- name: Remove shortcut for the occ command
+  file:
+    path: '/usr/local/bin/occ'
+    state: 'absent'
+  when: not owncloud_enable_occ_shortcut|d()
   tags: [ 'role::owncloud:occ' ]
 
 - name: Run specified occ commands
-  command: occ {{ item.command }}
+  command: php --file "{{ owncloud_home }}/occ" {{ item.command }}
   environment: '{{ item.env|d({}) }}'
   changed_when: ('is already enabled' not in owncloud_occ_run.stdout and
                   'already exists' not in owncloud_occ_run.stdout)
   failed_when: (owncloud_occ_run.rc != 0 and 'already exists' not in owncloud_occ_run.stdout)
   no_log: True
   register: owncloud_occ_run
+  sudo_user: '{{ owncloud_user }}'
   when: item|d() and item.command|d()
   with_flattened:
     - owncloud_run_occ_global_commands

--- a/tasks/configure_owncloud.yml
+++ b/tasks/configure_owncloud.yml
@@ -96,6 +96,7 @@
   changed_when: ('is already enabled' not in owncloud_occ_run.stdout and
                   'already exists' not in owncloud_occ_run.stdout)
   failed_when: (owncloud_occ_run.rc != 0 and 'already exists' not in owncloud_occ_run.stdout)
+  no_log: True
   register: owncloud_occ_run
   when: item|d() and item.command|d()
   with_flattened:

--- a/templates/usr/local/bin/occ.j2
+++ b/templates/usr/local/bin/occ.j2
@@ -2,4 +2,12 @@
 
 # {{ ansible_managed }}
 
-sudo --user {{ owncloud_user }} php --file "{{ owncloud_home }}/occ" "$@"
+# Environment variable `OC_PASS` is striped normally by `sudo`.
+# `--preserve-env` would preserve all environment variables.
+# This should be OK for this command.
+# It seems to be impossible to set "env_keep" via the command line?
+# Other possibility would be to configure it properly via Defaults!{{ owncloud_home }}/occ env_keep=OC_PASS
+#
+# https://doc.owncloud.org/server/8.1/admin_manual/configuration_server/occ_command.html#user-commands
+
+sudo --preserve-env --user {{ owncloud_user }} php --file "{{ owncloud_home }}/occ" "$@"

--- a/templates/usr/local/bin/occ.j2
+++ b/templates/usr/local/bin/occ.j2
@@ -1,4 +1,5 @@
 #!/bin/bash
+## Shortcut for running ownClouds `occ` command when not logged in as {{ owncloud_user }} user and sudo allows it.
 
 # {{ ansible_managed }}
 


### PR DESCRIPTION
Turns out that the `occ` commands only accepts the password via
environment variables which is a good thing.

What should we do with the sudo environment thing?
