### PR TITLE
`owncloud_custom_conf_map` did fail in condition when containing a list.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,7 +37,7 @@
     owner: '{{ owncloud_user }}'
     group: '{{ owncloud_group }}'
     mode: 0640
-  when: owncloud_custom_conf_map
+  when: (owncloud_custom_conf_map is defined and owncloud_custom_conf_map is mapping)
   tags: [ 'role::owncloud:custom_config' ]
 
 - include: configure_mysql.yml


### PR DESCRIPTION
Failed:

``` YAML
owncloud_custom_conf_map:
  trusted_domains: '{{ owncloud_domain }}'
```
