### PR TITLE
Check automatically finish setup if allowed

### DIFF
--- a/tasks/configure_owncloud.yml
+++ b/tasks/configure_owncloud.yml
@@ -84,11 +84,22 @@
   when: owncloud_config_file is defined and not owncloud_config_file.stat.exists and
         owncloud_admin_username and owncloud_autosetup
 
+- name: Test availability of automatically finish setup
+  uri:
+    url: '{{ owncloud_autosetup_url }}'
+    status_code: '200,401'
+  register: owncloud_auto_finish_setup
+  when: owncloud_config_file is defined and not owncloud_config_file.stat.exists and
+        owncloud_admin_username and owncloud_autosetup
+
 - name: Automatically finish setup if allowed
   uri:
     url: '{{ owncloud_autosetup_url }}'
   when: owncloud_config_file is defined and not owncloud_config_file.stat.exists and
-        owncloud_admin_username and owncloud_autosetup
+        owncloud_admin_username and owncloud_autosetup and
+        owncloud_auto_finish_setup is defined and
+        owncloud_auto_finish_setup.status is defined and
+        owncloud_auto_finish_setup.status|int != 200
 
 - name: Allow to use the PHP CLI even if OCMemcacheAPCu is used
   template:


### PR DESCRIPTION
Under some conditions, the first request to owncloud_autosetup_url,
returns a status other than 200. In this case, all subsequent requests
owncloud_autosetup_url return a status of 200.

Signed-off-by: Aleksey Avdeev solo@altlinux.ru
