### PR TITLE
fixed php package names

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,7 +44,7 @@ owncloud__base_packages:
 #
 # List of base PHP packages required by ownCloud.
 owncloud__base_php_packages:
-  - 'apcu'
+  - 'php-apcu'
   - '{{ [ "mysql" ] if (owncloud__database in [ "mariadb", "mysql" ]) else [] }}'
   - '{{ [ "pgsql" ] if (owncloud__database in [ "postgresql" ]) else [] }}'
   - '{{ [ "redis" ] if (owncloud__redis_enabled | bool) else [] }}'
@@ -53,7 +53,7 @@ owncloud__base_php_packages:
   ## Seems to be required at least for PHP7.0 to fix:
   ## PHP Warning: PHP Startup: Unable to load dynamic library '/usr/lib/php/20151012/redis.so'
   ## - /usr/lib/php/20151012/redis.so: undefined symbol: igbinary_serialize in Unknown on line 0
-  - '{{ [ "igbinary" ]
+  - '{{ [ "php-igbinary" ]
         if (not (ansible_distribution == "Ubuntu" and (ansible_distribution_version|version_compare("15.10", "<"))))
         else [] }}'
 
@@ -68,7 +68,7 @@ owncloud__base_php_packages:
 #
 # List of optional PHP packages for ownCloud.
 owncloud__optional_php_packages:
-  - 'imagick'
+  - 'php-imagick'
 
 
 # .. envvar:: owncloud__packages


### PR DESCRIPTION
The installation currently fails with the following message: `"No package matching 'php7.0-imagick' is available"`.

Reason is the package installation logic in [debops.php](https://github.com/debops/ansible-php/blob/master/tasks/main.yml#L8) which appends the php version to each item not matching `php`. 

This PR fixes the issue.
