### PR TITLE
Fix breakage of apt policy as non root user thus of ansible core facts

### DIFF
--- a/tasks/system_package_management.yml
+++ b/tasks/system_package_management.yml
@@ -45,7 +45,7 @@
     dest: '/etc/apt/sources.list.d/debops_owncloud.list'
     owner: 'root'
     group: 'root'
-    mode: '0420'
+    mode: '0644'
   register: owncloud__register_apt_repository
 
 - name: Update APT repository cache


### PR DESCRIPTION
Fixes the permission for the apt source file, thus let apt run as non
root user without a permission error (owncloud one was 0420 instead of 0644
for the apt sources file).

before lsb_release which relies on apt policy (and is run a ssh user
by debops/ansible thus root here) ended up with codename
'testing/unstable' and release 'n/a'.
With the permission fixed to 0644 lsb_release gives codename 'stretch'
and release 'testing' or codename 'sid' and release 'unstable' depending
if there is a release line holding 'sid' or 'unstable' from apt policy
output.

This and a debops.core task "debops.core : Install core fact script" run
fixes the ansible core facts file.
