### PR TITLE
Rename owncloud__theme_entitiy_name to owncloud__theme_entity_name

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1336,17 +1336,17 @@ owncloud__theme_name: 'DebOps Cloud'
 owncloud__theme_name_html: '{{ owncloud__theme_name }}'
 
 
-# .. envvar:: owncloud__theme_entitiy_name
+# .. envvar:: owncloud__theme_entity_name
 #
 # Entity string for your ownCloud. For example the name of your company. This
 # string is used in the footer and the copyright.
-owncloud__theme_entitiy_name: 'DebOps'
+owncloud__theme_entity_name: 'DebOps'
 
 
 # .. envvar:: owncloud__theme_base_url
 #
 # Base URL to get more information about your ownCloud. By default,
-# :envvar:`owncloud__theme_entitiy_name` links to this URL on the login page.
+# :envvar:`owncloud__theme_entity_name` links to this URL on the login page.
 # Use an empty string to use the default URL pointing to the ownCloud website.
 owncloud__theme_base_url: 'https://github.com/debops/ansible-owncloud'
 

--- a/templates/srv/www/sites/themes/debops-template/defaults.php.j2
+++ b/templates/srv/www/sites/themes/debops-template/defaults.php.j2
@@ -114,7 +114,7 @@ Fallback not possible as of 9.0.2.
 	 * @return string entity name
 	 */
 	public function getEntity() {
-		return '{{ owncloud__theme_entitiy_name }}';
+		return '{{ owncloud__theme_entity_name }}';
 	}
 
 	/**


### PR DESCRIPTION
Typo fix. Should we allow the old variable name to not break existing configurations?