### PR TITLE
Ensure the `unzip` package is installed when deploying Nextcloud

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,6 +32,9 @@ owncloud__base_packages:
   - '{{ [ "owncloud" ]
         if (owncloud__variant == "owncloud")
         else [] }}'
+  - '{{ [ "unzip" ]
+        if (owncloud__variant == "nextcloud")
+        else [] }}'
 
   # There are no Debian packages for Nextcloud yet unfortunately.
 


### PR DESCRIPTION
Changelog entry not required because only the unreleased version of the role is affected. It is long enough already :)

Thanks to: @damko
Related to: https://github.com/debops/ansible-owncloud/pull/83#issuecomment-317192380